### PR TITLE
Remove the [lib] section to avoid unneccessarily building a dylib.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,6 @@ exclude = [
     "tests/*",
 ]
 
-[lib]
-name = "gif"
-crate-type = ["dylib", "rlib"]
-
 [dependencies]
 lzw = "0.8"
 color_quant = "1.0"


### PR DESCRIPTION
Generating the extra dylib both takes time and complicates some of the linking code on some of our non-traditional Servo platforms (e.g., gonk/B2G and Android). If there isn't some reason to have the extra [lib] section and be producing both a dylib and rlib, it would be great if we can remove this.

Thanks!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/pistondevelopers/image-gif/3)
<!-- Reviewable:end -->
