### PR TITLE
If decoding an invalid disposal value, default to Any rather than failing.

### DIFF
--- a/src/reader/decoder.rs
+++ b/src/reader/decoder.rs
@@ -376,9 +376,7 @@ impl StreamingDecoder {
                             (control_flags & 0b11100) >> 2
                         ) {
                             Some(method) => method,
-                            None => return Err(DecodingError::Format(
-                                "unknown disposal method"
-                            ))
+                            None => DisposalMethod::Any
                         };
                         goto!(U16(U16Value::Delay))
                     }


### PR DESCRIPTION
Unfortunately, malformed GIFs exist in the wild, and it's often necessary to be able to
handle them. While I don't think silently ignoring invalid disposals is ideal, I believe
this is the most useful behavior given the current API design.