### PR TITLE
Ignore global background color if out-of-bounds

### DIFF
--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -179,6 +179,12 @@ impl<R> Reader<R> where R: Read {
                 ))
             }
         }
+        // If the background color is invalid, ignore it
+        if let &Some(ref palette) = &self.global_palette {
+            if self.bg_color.unwrap_or(0) as usize >= palette.len() {
+                self.bg_color = None;
+            }
+        }
         Ok(self)
     }
     


### PR DESCRIPTION
This is a fix for https://github.com/PistonDevelopers/image/issues/816.

Some GIF files use an invalid background color if the background color is never used. To support this, this change ignores the background color if its index is invalid.

An alternative would be to return an error, but this would break files which are correctly decoded today.